### PR TITLE
Fix a few issues with quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ fs.writeFileSync('out_file.csv', csv);
 #### Options
 
 The `csvsync.stringify` function accepts an optional second parameter
-– an object with options.  Currently, two options are supported:
-`delimiter` (`','` by default) and `quoteAll` (`false` by default).
+– an object with options.  Currently, three are supported:
+`delimiter` (`','` by default), `quoteAll` (`false` by default), and
+`quoteEmpty` (`false` by default).
 
 # Installation
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function stringify(data, opts) {
 	opts = opts || {};
 	var delimiter = opts.delimiter || ',';
 	var quoteAll = opts.quoteAll;
+	var quoteEmpty = opts.quoteEmpty;
 
 	// iterate rows
 	return data.reduce(function(csv, row) {
@@ -20,6 +21,7 @@ function stringify(data, opts) {
 				// enclose the field in " " if it contains dangerous chars
 				if (
 					quoteAll ||
+					(quoteEmpty && field === '') ||
 					field.indexOf(delimiter) > -1 ||
 					field.indexOf('\n') > -1 ||
 					field.indexOf('"') > -1
@@ -124,6 +126,9 @@ function parse(csv, opts) {
 		// use ^^QUOTE@@ as this is something we don't expect to occur in the wild
 		line = line.replace(/^"""/, '"^^QUOTE@@');
 		line = line.replace(/,"""/g, ',"^^QUOTE@@');
+		line = line.replace(/,"",/g, ',,');
+		line = line.replace(/^"",/g, ',');
+		line = line.replace(/,""$/g, ',');
 		line = line.replace(/""/g, '^^QUOTE@@');
 
 		do {

--- a/test.js
+++ b/test.js
@@ -23,6 +23,22 @@ test('csv reading and writing', function(t) {
 			js: [['Active "Sum"', 'bar'], ['3', '2'], ['4', '5']],
 		},
 		{
+			name: 'empty field in quotes',
+			csv: '"",1\n',
+			js: [['', '1']],
+			stringifyOpts: { quoteEmpty: true },
+		},
+		{
+			name: 'quoted quote at bol',
+			csv: '"""",1\n',
+			js: [['"', '1']],
+		},
+		{
+			name: 'quoted quote at eol',
+			csv: '1,""""\n',
+			js: [['1', '"']],
+		},
+		{
 			name: 'quotes in field at end of line',
 			csv: '"Active ""Sum""",bar\n3,2\n4,"some ""test"""\n',
 			js: [['Active "Sum"', 'bar'], ['3', '2'], ['4', 'some "test"']],


### PR DESCRIPTION
A quoted empty field was incorrectly parsed as a field containing
a single quote.  This patch fixes it, but causes a bug in the case of
a field containing a comma, a quote and a comma.  This will be
addressed in another patch.