### PR TITLE
Fix the `main` property in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "csvsync",
   "version": "1.3.2",
   "description": "csv reader and writer working synchronously",
-  "main": "csvsync.js",
+  "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/tape test.js | ./node_modules/.bin/tap-spec"
   },


### PR DESCRIPTION
This silences the `[DEP0128] DeprecationWarning: Invalid 'main' field in '[redacted]/csvsync/package.json' of 'csvsync.js'.` warning.